### PR TITLE
Clamp expanded inventory size to valid range

### DIFF
--- a/MultiServer/Source/DataServerDB.cpp
+++ b/MultiServer/Source/DataServerDB.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "DataServerDB.h"
 #include "zMultiServer.h"
+#include <algorithm>
 
 CQuery g_DataServerDB;
 
@@ -1606,13 +1607,14 @@ char szQuery[256];
 
 void ExpandInventory(char* szAccountID,char* szName,int count)
 {
-	char szQuery[256];
+        char szQuery[256];
 
-	sprintf(szQuery,"UPDATE Character SET ExInventory = %d WHERE AccountID = '%s' AND Name = '%s'",
-		count,szAccountID,szName);
+        int clamped = std::clamp(count, 1, 4);
+        sprintf(szQuery,"UPDATE Character SET ExInventory = %d WHERE AccountID = '%s' AND Name = '%s'",
+                clamped,szAccountID,szName);
 
-	g_DataServerDB.Exec(szQuery);
-	g_DataServerDB.Clear();
+        g_DataServerDB.Exec(szQuery);
+        g_DataServerDB.Clear();
 }
 
 void MuBotSaveOption(char* szName,LPMUBOT_SETTINGS_REQ_SAVE lpMsg)

--- a/Server/Source/DSProtocol.cpp
+++ b/Server/Source/DSProtocol.cpp
@@ -2058,58 +2058,12 @@ void JGGetCharacterInfo( SDHP_DBCHAR_INFORESULT * lpMsg)
 	pjMsg.MaxAddPoint = MaxAddPoint;
 	pjMsg.wMinusPoint = MinusPoint;
 	pjMsg.wMaxMinusPoint = MaxMinusPoint;
-	//Here fix btExInventory to btInventoryExpansion
-	//This works
-	/*
-	pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	*/
-	//This works
-
-	// Try to fix it
-	//Working
-	/*
-	if ( lpObj->pInventoryExtend > 4) {
-		lpObj->pInventoryExtend = 4;
-		pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	}
-	else {
-		pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	}
-	*/
-	//Working
-	// Try to fix it
-
-	// Full Fixed
-	if ( lpObj->pInventoryExtend > 4) {
-		lpObj->pInventoryExtend = 4;
-		pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	}
-	if ( lpObj->pInventoryExtend <= 0) {
-		lpObj->pInventoryExtend = 4;
-		pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	}
-	if ( lpObj->pInventoryExtend = 1) {
-		lpObj->pInventoryExtend = 4;
-		pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	}
-	if ( lpObj->pInventoryExtend = 2) {
-		lpObj->pInventoryExtend = 4;
-		pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	}
-	if ( lpObj->pInventoryExtend = 3) {
-		lpObj->pInventoryExtend = 4;
-		pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	}
-	if ( lpObj->pInventoryExtend = 4) {
-		lpObj->pInventoryExtend = 4;
-		pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	}
-	else {
-		lpObj->pInventoryExtend = 4;
-		pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
-	}
-	// Full Fixed
-
+        pjMsg.btInventoryExpansion = lpObj->pInventoryExtend;
+        if (pjMsg.btInventoryExpansion < 1 || pjMsg.btInventoryExpansion > 4)
+        {
+                pjMsg.btInventoryExpansion = 4;
+                lpObj->pInventoryExtend = 4;
+        }
 	//Added for Test
 	LogAddTD("[Expanded Inventory System] [%s][%s] (Expanded Inventory Number:%d)",
 		lpObj->AccountID, lpObj->Name, lpObj->pInventoryExtend);
@@ -3538,7 +3492,7 @@ void DGMoveOtherServer(SDHP_CHARACTER_TRANSFER_RESULT * lpMsg)
 		
 		lpObj->m_MoveOtherServer = 0;
 		
-		GCServerMsgStringSend("¹®Á¦ ¹ß»ý½Ã change@webzen.co.kr·Î ¹®ÀÇÇØ ÁÖ½Ã±â¹Ù¶ø´Ï´Ù",lpObj->m_Index, 1);
+		GCServerMsgStringSend("ë¬¸ì œ ë°œìƒì‹œ change@webzen.co.krë¡œ ë¬¸ì˜í•´ ì£¼ì‹œê¸°ë°”ëžë‹ˆë‹¤",lpObj->m_Index, 1);
 		// Deathway translation here
 		return;
 	}
@@ -3546,8 +3500,8 @@ void DGMoveOtherServer(SDHP_CHARACTER_TRANSFER_RESULT * lpMsg)
 	LogAddTD("[CharTrasfer] Success [%s][%s] (%d)",
 		lpObj->AccountID, lpObj->Name, lpMsg->Result);
 
-	GCServerMsgStringSend("Á¢¼ÓÀÌ Á¾·áµË´Ï´Ù.", lpObj->m_Index, 1);// Deathway translation here
-	GCServerMsgStringSend("ºÐÇÒ ¼­¹ö·Î Á¢¼ÓÇØÁÖ½Ã±â ¹Ù¶ø´Ï´Ù.", lpObj->m_Index, 1);// Deathway translation here
+	GCServerMsgStringSend("ì ‘ì†ì´ ì¢…ë£Œë©ë‹ˆë‹¤.", lpObj->m_Index, 1);// Deathway translation here
+	GCServerMsgStringSend("ë¶„í•  ì„œë²„ë¡œ ì ‘ì†í•´ì£¼ì‹œê¸° ë°”ëžë‹ˆë‹¤.", lpObj->m_Index, 1);// Deathway translation here
 	GJSetCharacterInfo(lpObj, lpObj->m_Index, 0);
 	lpObj->LoadWareHouseInfo = false;
 	gObjCloseSet(lpObj->m_Index, 2);

--- a/Server/Source/user.cpp
+++ b/Server/Source/user.cpp
@@ -77,6 +77,7 @@
 #include "..\pugixml\pugixml.hpp"
 #include "MapRateInfo.h"
 #include "ShopPointEx.h"
+#include <algorithm>
 
 #if (ENABLE_CUSTOM_OFFLINETRADE == 1)
 #include "OfflineTrade.h"
@@ -1294,8 +1295,8 @@ void gObjCharZeroSet(int aIndex)
 #endif
 
 	lpObj->pTransaction = 0;
-	//Here to change 0 to 4
-	lpObj->pInventoryExtend = 0;
+	//Initialize expanded inventory with a safe default size
+	lpObj->pInventoryExtend = 4;
 	gObjMonsterHitDamageInit(lpObj);
 	gObjSetInventory1Pointer(&gObj[aIndex]);
 


### PR DESCRIPTION
## Summary
- Clamp player inventory expansion in DSProtocol to 1-4 before sending to client
- Guard DataServer inventory writes with std::clamp
- Initialize players with a safe default expanded inventory size

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `cd MultiServer && make` *(fails: No targets specified and no makefile found)*
- `cd Server && make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ad4755fc83329e01fb4ae3b47aef