### PR TITLE
Add sequence and CRC validation for Ertel packets

### DIFF
--- a/MultiServer/Source/DataServer.cpp
+++ b/MultiServer/Source/DataServer.cpp
@@ -5,6 +5,53 @@
 #include "DataServerDB.h"
 #include "winutil.h"
 
+namespace
+{
+        DWORD CRC32Init()
+        {
+                return 0xFFFFFFFFu;
+        }
+
+        DWORD CRC32Update(DWORD crc, const BYTE* data, int length)
+        {
+                if ( data == NULL || length <= 0 )
+                {
+                        return crc;
+                }
+
+                for ( int i = 0; i < length; ++i )
+                {
+                        crc ^= data[i];
+
+                        for ( int j = 0; j < 8; ++j )
+                        {
+                                DWORD mask = -(int)(crc & 1);
+                                crc = (crc >> 1) ^ (0xEDB88320u & mask);
+                        }
+                }
+
+                return crc;
+        }
+
+        DWORD CRC32Finalize(DWORD crc)
+        {
+                return ~crc;
+        }
+
+        DWORD CRC32Calculate(const BYTE* data, int length)
+        {
+                return CRC32Finalize(CRC32Update(CRC32Init(), data, length));
+        }
+
+        DWORD CRC32Calculate(const BYTE* first, int firstLength, const BYTE* second, int secondLength)
+        {
+                DWORD crc = CRC32Init();
+                crc = CRC32Update(crc, first, firstLength);
+                crc = CRC32Update(crc, second, secondLength);
+                return CRC32Finalize(crc);
+        }
+}
+
 DS_INFO g_DSInfo;
 
 void DataServerInit()
@@ -1772,27 +1819,45 @@ void DGMuBotOptionRecv(LPMUBOT_SETTINGS_REQ_SAVE lpMsg,int aIndex)
 
 void DGAnsErtelList(LPMSG_REQ_ERTELLIST lpMsg,int aIndex)
 {
-	char szName[MAX_IDSTRING+1];
-	char szAccount[MAX_IDSTRING+1];
+        char szName[MAX_IDSTRING+1];
+        char szAccount[MAX_IDSTRING+1];
 
-	memcpy(szAccount,lpMsg->szAccount,MAX_IDSTRING);
-	szAccount[MAX_IDSTRING] = '\0';
+        memcpy(szAccount,lpMsg->szAccount,MAX_IDSTRING);
+        szAccount[MAX_IDSTRING] = '\0';
 
-	memcpy(szName,lpMsg->szName,MAX_IDSTRING);
-	szName[MAX_IDSTRING] = '\0';
+        memcpy(szName,lpMsg->szName,MAX_IDSTRING);
+        szName[MAX_IDSTRING] = '\0';
 
-	PMSG_ANS_ERTELLIST pMsg;
-	pMsg.h.c = 0xC2;
-	pMsg.h.sizeH = SET_NUMBERH(sizeof(pMsg));
-	pMsg.h.sizeL = SET_NUMBERL(sizeof(pMsg));
-	pMsg.h.headcode = 0xA4;
+        DWORD expectedRequestCRC = CRC32Calculate((const BYTE*)lpMsg->szAccount, 10, (const BYTE*)lpMsg->szName, 10);
 
-	pMsg.aIndex = lpMsg->aIndex;
-	memcpy(pMsg.szName,szName,10);
+        if ( lpMsg->dwCRC != expectedRequestCRC )
+        {
+                g_Window.ServerLogAdd(ST_DATASERVER,
+                        "[ErtelSync] Request CRC mismatch seq:%u [%s][%s] expected:%08X received:%08X",
+                        lpMsg->dwSequence, szAccount, szName, expectedRequestCRC, lpMsg->dwCRC);
+        }
 
-	GetErtelList(szAccount,szName,&pMsg);
+        PMSG_ANS_ERTELLIST pMsg;
+        memset(&pMsg, 0, sizeof(pMsg));
+        pMsg.h.c = 0xC2;
+        pMsg.h.sizeH = SET_NUMBERH(sizeof(pMsg));
+        pMsg.h.sizeL = SET_NUMBERL(sizeof(pMsg));
+        pMsg.h.headcode = 0xA4;
 
-	DataSend(aIndex,(LPBYTE)&pMsg,sizeof(pMsg));
+        pMsg.aIndex = lpMsg->aIndex;
+        memcpy(pMsg.szName,szName,10);
+
+        pMsg.dwSequence = lpMsg->dwSequence;
+
+        GetErtelList(szAccount,szName,&pMsg);
+
+        pMsg.dwCRC = CRC32Calculate(pMsg.ErtelList1, sizeof(pMsg.ErtelList1), pMsg.ErtelList2, sizeof(pMsg.ErtelList2));
+
+        g_Window.ServerLogAdd(ST_DATASERVER,
+                "[ErtelSync] DGAnsErtelList seq:%u [%s][%s] crc:%08X",
+                pMsg.dwSequence, szAccount, szName, pMsg.dwCRC);
+
+        DataSend(aIndex,(LPBYTE)&pMsg,sizeof(pMsg));
 }
 
 void DGSaveErtelList(LPMSG_SAVE_ERTELLIST lpMsg)

--- a/MultiServer/Source/DataServer.h
+++ b/MultiServer/Source/DataServer.h
@@ -1438,20 +1438,24 @@ typedef struct
 
 typedef struct
 {
-	PBMSG_HEAD h;
-	int aIndex;
-	char szAccount[10];
-	char szName[10];
+        PBMSG_HEAD h;
+        int aIndex;
+        char szAccount[10];
+        char szName[10];
+        DWORD dwSequence;
+        DWORD dwCRC;
 }PMSG_REQ_ERTELLIST, *LPMSG_REQ_ERTELLIST;
 
 typedef struct
 {
-	PWMSG_HEAD h;
-	int aIndex;
-	char szName[10];
+        PWMSG_HEAD h;
+        int aIndex;
+        char szName[10];
 
-	BYTE ErtelList1[700];
-	BYTE ErtelList2[700];
+        BYTE ErtelList1[700];
+        BYTE ErtelList2[700];
+        DWORD dwSequence;
+        DWORD dwCRC;
 }PMSG_ANS_ERTELLIST, *LPMSG_ANS_ERTELLIST;
 
 typedef struct

--- a/Server/Source/DSProtocol.cpp
+++ b/Server/Source/DSProtocol.cpp
@@ -7,6 +7,7 @@
 
 
 #include "stdafx.h"
+#include <stddef.h>
 #include "DSProtocol.h"
 #include "logproc.h"
 #include "DBSockMng.h"
@@ -359,8 +360,113 @@ void DataServerProtocolCore(BYTE protoNum, unsigned char* aRecv, int aLen)
 			JGPSummonerInfo((PMSG_ANS_SUMMONER_CREATE*)aRecv);
 			break;
 		case 0xA4:
-			g_ElementalSystem.DGAnsErtelList((PMSG_ANS_ERTELLIST*)aRecv);
-			break;
+		{
+			if ( aLen < (int)(sizeof(PWMSG_HEAD) + sizeof(int)) )
+			{
+				LogAddTD("[ErtelSync] Received Ertel list packet with insufficient length (%d)", aLen);
+				break;
+			}
+
+			PMSG_ANS_ERTELLIST* lpMsg = (PMSG_ANS_ERTELLIST*)aRecv;
+			int packetSize = (lpMsg->h.sizeH << 8) | lpMsg->h.sizeL;
+			int minimumSize = sizeof(PMSG_ANS_ERTELLIST);
+			int aIndex = lpMsg->aIndex;
+
+			if ( packetSize < minimumSize || aLen < minimumSize )
+			{
+				const int sequenceOffset = (int)(offsetof(PMSG_ANS_ERTELLIST, dwSequence) + sizeof(lpMsg->dwSequence));
+				DWORD truncatedSequence = 0;
+
+				if ( aLen >= sequenceOffset )
+				{
+					truncatedSequence = lpMsg->dwSequence;
+				}
+
+				LogAddTD("[ErtelSync] Truncated Ertel list packet len:%d/%d seq:%u index:%d",
+						aLen, minimumSize, truncatedSequence, aIndex);
+
+				if ( OBJMAX_RANGE(aIndex) && g_ElementalSystem.CanRetryErtelRequest(aIndex) )
+				{
+					LogAddTD("[ErtelSync] Requesting resend due to truncated packet index:%d seq:%u",
+							aIndex, truncatedSequence);
+					g_ElementalSystem.GDReqErtelList(aIndex);
+				}
+
+				break;
+			}
+
+			if ( !OBJMAX_RANGE(aIndex) )
+			{
+				LogAddTD("[ErtelSync] Received Ertel list with invalid index:%d seq:%u",
+						aIndex, lpMsg->dwSequence);
+				break;
+			}
+
+			char szAccount[11];
+			char szName[11];
+
+			memcpy(szAccount, gObj[aIndex].AccountID, 10);
+			szAccount[10] = '\0';
+
+			memcpy(szName, lpMsg->szName, 10);
+			szName[10] = '\0';
+
+			DWORD expectedSequence = g_ElementalSystem.GetPendingErtelSequence(aIndex);
+
+			if ( expectedSequence != 0 && expectedSequence != lpMsg->dwSequence )
+			{
+				LogAddTD("[ErtelSync] Sequence mismatch [%s][%s] expected:%u received:%u",
+						szAccount, szName, expectedSequence, lpMsg->dwSequence);
+
+				if ( g_ElementalSystem.CanRetryErtelRequest(aIndex) )
+				{
+					LogAddTD("[ErtelSync] Requesting resend due to sequence mismatch [%s][%s]",
+							szAccount, szName);
+					g_ElementalSystem.GDReqErtelList(aIndex);
+				}
+				else
+				{
+					LogAddTD("[ErtelSync] Retry limit reached for sequence mismatch [%s][%s]",
+							szAccount, szName);
+				}
+
+				break;
+			}
+
+			if ( expectedSequence == 0 )
+			{
+				LogAddTD("[ErtelSync] Received Ertel list without pending sequence [%s][%s] seq:%u",
+						szAccount, szName, lpMsg->dwSequence);
+			}
+
+			DWORD computedCRC = g_ElementalSystem.BuildErtelDataCRC(
+				lpMsg->ErtelList1, sizeof(lpMsg->ErtelList1),
+				lpMsg->ErtelList2, sizeof(lpMsg->ErtelList2));
+
+			if ( computedCRC != lpMsg->dwCRC )
+			{
+				LogAddTD("[ErtelSync] CRC mismatch [%s][%s] seq:%u expected:%08X received:%08X",
+						szAccount, szName, lpMsg->dwSequence, computedCRC, lpMsg->dwCRC);
+
+				if ( g_ElementalSystem.CanRetryErtelRequest(aIndex) )
+				{
+					LogAddTD("[ErtelSync] Requesting resend due to CRC mismatch [%s][%s]",
+							szAccount, szName);
+					g_ElementalSystem.GDReqErtelList(aIndex);
+				}
+				else
+				{
+					LogAddTD("[ErtelSync] Retry limit reached for CRC mismatch [%s][%s]",
+							szAccount, szName);
+				}
+
+				break;
+			}
+
+			g_ElementalSystem.CompleteErtelSequence(aIndex);
+			g_ElementalSystem.DGAnsErtelList(lpMsg);
+		}
+		break;
 		case 0xEF:
 			{
 				int subcode = -1;
@@ -3538,7 +3644,7 @@ void DGMoveOtherServer(SDHP_CHARACTER_TRANSFER_RESULT * lpMsg)
 		
 		lpObj->m_MoveOtherServer = 0;
 		
-		GCServerMsgStringSend("¹®Á¦ ¹ß»ý½Ã change@webzen.co.kr·Î ¹®ÀÇÇØ ÁÖ½Ã±â¹Ù¶ø´Ï´Ù",lpObj->m_Index, 1);
+		GCServerMsgStringSend("ë¬¸ì œ ë°œìƒì‹œ change@webzen.co.krë¡œ ë¬¸ì˜í•´ ì£¼ì‹œê¸°ë°”ëžë‹ˆë‹¤",lpObj->m_Index, 1);
 		// Deathway translation here
 		return;
 	}
@@ -3546,8 +3652,8 @@ void DGMoveOtherServer(SDHP_CHARACTER_TRANSFER_RESULT * lpMsg)
 	LogAddTD("[CharTrasfer] Success [%s][%s] (%d)",
 		lpObj->AccountID, lpObj->Name, lpMsg->Result);
 
-	GCServerMsgStringSend("Á¢¼ÓÀÌ Á¾·áµË´Ï´Ù.", lpObj->m_Index, 1);// Deathway translation here
-	GCServerMsgStringSend("ºÐÇÒ ¼­¹ö·Î Á¢¼ÓÇØÁÖ½Ã±â ¹Ù¶ø´Ï´Ù.", lpObj->m_Index, 1);// Deathway translation here
+	GCServerMsgStringSend("ì ‘ì†ì´ ì¢…ë£Œë©ë‹ˆë‹¤.", lpObj->m_Index, 1);// Deathway translation here
+	GCServerMsgStringSend("ë¶„í•  ì„œë²„ë¡œ ì ‘ì†í•´ì£¼ì‹œê¸° ë°”ëžë‹ˆë‹¤.", lpObj->m_Index, 1);// Deathway translation here
 	GJSetCharacterInfo(lpObj, lpObj->m_Index, 0);
 	lpObj->LoadWareHouseInfo = false;
 	gObjCloseSet(lpObj->m_Index, 2);

--- a/Server/Source/ElementalSystem.cpp
+++ b/Server/Source/ElementalSystem.cpp
@@ -23,11 +23,60 @@
 #include "Achievements.h"
 #endif
 
+namespace
+{
+        const int kMaxErtelRequestAttempts = 3;
+
+        DWORD CRC32Init()
+        {
+                return 0xFFFFFFFFu;
+        }
+
+        DWORD CRC32Update(DWORD crc, const BYTE* data, int length)
+        {
+                if ( data == NULL || length <= 0 )
+                {
+                        return crc;
+                }
+
+                for ( int i = 0; i < length; ++i )
+                {
+                        crc ^= data[i];
+
+                        for ( int j = 0; j < 8; ++j )
+                        {
+                                DWORD mask = -(int)(crc & 1);
+                                crc = (crc >> 1) ^ (0xEDB88320u & mask);
+                        }
+                }
+
+                return crc;
+        }
+
+        DWORD CRC32Finalize(DWORD crc)
+        {
+                return ~crc;
+        }
+
+        DWORD CRC32Calculate(const BYTE* data, int length)
+        {
+                return CRC32Finalize(CRC32Update(CRC32Init(), data, length));
+        }
+
+        DWORD CRC32Calculate(const BYTE* first, int firstLength, const BYTE* second, int secondLength)
+        {
+                DWORD crc = CRC32Init();
+                crc = CRC32Update(crc, first, firstLength);
+                crc = CRC32Update(crc, second, secondLength);
+                return CRC32Finalize(crc);
+        }
+}
+
 CElementalSystem g_ElementalSystem;
 
 CElementalSystem::CElementalSystem()
 {
-	// Added 2 x 00
+        // Added 2 x 00
 	m_DamageTable[ELEMENT_FIRE][ELEMENT_FIRE] = 500;
 	m_DamageTable[ELEMENT_FIRE][ELEMENT_WATER] = 580;
 	m_DamageTable[ELEMENT_FIRE][ELEMENT_EARTH] = 590;
@@ -52,14 +101,16 @@ CElementalSystem::CElementalSystem()
 	m_DamageTable[ELEMENT_WIND][ELEMENT_WIND] = 500;
 	m_DamageTable[ELEMENT_WIND][ELEMENT_DARK] = 580;
 
-	m_DamageTable[ELEMENT_DARK][ELEMENT_FIRE] = 580;
-	m_DamageTable[ELEMENT_DARK][ELEMENT_WATER] = 590;
-	m_DamageTable[ELEMENT_DARK][ELEMENT_EARTH] = 510;
-	m_DamageTable[ELEMENT_DARK][ELEMENT_WIND] = 520;
-	m_DamageTable[ELEMENT_DARK][ELEMENT_DARK] = 500;
+        m_DamageTable[ELEMENT_DARK][ELEMENT_FIRE] = 580;
+        m_DamageTable[ELEMENT_DARK][ELEMENT_WATER] = 590;
+        m_DamageTable[ELEMENT_DARK][ELEMENT_EARTH] = 510;
+        m_DamageTable[ELEMENT_DARK][ELEMENT_WIND] = 520;
+        m_DamageTable[ELEMENT_DARK][ELEMENT_DARK] = 500;
 
-	memset(this->m_ErtelOption,-1,sizeof(m_ErtelOption));
-	memset(this->m_classinfo,0,sizeof(this->m_classinfo));
+        memset(this->m_ErtelOption,-1,sizeof(m_ErtelOption));
+        memset(this->m_classinfo,0,sizeof(this->m_classinfo));
+
+        m_ErtelSequenceCounter = 0;
 }
 
 CElementalSystem::~CElementalSystem()
@@ -2433,16 +2484,108 @@ BOOL CElementalSystem::Attack(LPOBJ lpObj, LPOBJ lpTargetObj, CMagicInf* lpMagic
 	return TRUE;
 }
 
+DWORD CElementalSystem::GetNextErtelSequence()
+{
+        ++m_ErtelSequenceCounter;
+
+        if ( m_ErtelSequenceCounter == 0 )
+        {
+                ++m_ErtelSequenceCounter;
+        }
+
+        return m_ErtelSequenceCounter;
+}
+
+DWORD CElementalSystem::BuildErtelDataCRC(const BYTE* list1, int list1Size, const BYTE* list2, int list2Size) const
+{
+        return CRC32Calculate(list1, list1Size, list2, list2Size);
+}
+
+DWORD CElementalSystem::BuildErtelRequestCRC(const char* account, const char* name) const
+{
+        BYTE buffer[20];
+        memcpy(buffer, account, 10);
+        memcpy(buffer + 10, name, 10);
+        return CRC32Calculate(buffer, sizeof(buffer));
+}
+
+DWORD CElementalSystem::GetPendingErtelSequence(int aIndex) const
+{
+        std::map<int, DWORD>::const_iterator it = m_mapPendingErtelSequences.find(aIndex);
+
+        if ( it == m_mapPendingErtelSequences.end() )
+        {
+                return 0;
+        }
+
+        return it->second;
+}
+
+void CElementalSystem::CompleteErtelSequence(int aIndex)
+{
+        m_mapPendingErtelSequences.erase(aIndex);
+        m_mapErtelRetryCount.erase(aIndex);
+}
+
+bool CElementalSystem::CanRetryErtelRequest(int aIndex) const
+{
+        return GetErtelRetryCount(aIndex) < kMaxErtelRequestAttempts;
+}
+
+int CElementalSystem::GetErtelRetryCount(int aIndex) const
+{
+        std::map<int, int>::const_iterator it = m_mapErtelRetryCount.find(aIndex);
+
+        if ( it == m_mapErtelRetryCount.end() )
+        {
+                return 0;
+        }
+
+        return it->second;
+}
+
 void CElementalSystem::GDReqErtelList(int aIndex)
 {
-	PMSG_REQ_ERTELLIST pMsg;
-	PHeadSetB((LPBYTE)&pMsg,0xA4,sizeof(pMsg));
+        if ( aIndex < 0 || aIndex >= OBJMAX )
+        {
+                return;
+        }
 
-	pMsg.aIndex = aIndex;
-	memcpy(pMsg.szAccount,gObj[aIndex].AccountID,10);
-	memcpy(pMsg.szName,gObj[aIndex].Name,10);
+        PMSG_REQ_ERTELLIST pMsg;
+        PHeadSetB((LPBYTE)&pMsg,0xA4,sizeof(pMsg));
 
-	cDBSMng.Send((PCHAR)&pMsg,sizeof(pMsg));
+        pMsg.aIndex = aIndex;
+        char szAccount[11];
+        char szName[11];
+
+        memcpy(szAccount, gObj[aIndex].AccountID, 10);
+        szAccount[10] = '\0';
+
+        memcpy(szName, gObj[aIndex].Name, 10);
+        szName[10] = '\0';
+
+        int attempt = ++m_mapErtelRetryCount[aIndex];
+
+        if ( attempt > kMaxErtelRequestAttempts )
+        {
+                m_mapErtelRetryCount[aIndex] = kMaxErtelRequestAttempts;
+
+                LogAddTD("[ErtelSync] Request attempt limit reached (%d) [%s][%s]", attempt,
+                        szAccount, szName);
+
+                return;
+        }
+
+        memcpy(pMsg.szAccount, szAccount, 10);
+        memcpy(pMsg.szName, szName, 10);
+
+        pMsg.dwSequence = GetNextErtelSequence();
+        m_mapPendingErtelSequences[aIndex] = pMsg.dwSequence;
+        pMsg.dwCRC = BuildErtelRequestCRC(pMsg.szAccount, pMsg.szName);
+
+        cDBSMng.Send((PCHAR)&pMsg,sizeof(pMsg));
+
+        LogAddTD("[ErtelSync] GDReqErtelList seq:%u attempt:%d [%s][%s]", pMsg.dwSequence, attempt, szAccount, szName);
 }
 
 void CElementalSystem::DGAnsErtelList(PMSG_ANS_ERTELLIST* lpMsg)

--- a/Server/Source/ElementalSystem.h
+++ b/Server/Source/ElementalSystem.h
@@ -2,6 +2,7 @@
 #define __ELEMENTALSYSTEM_H__
 
 #include "..\common\zzzitem.h"
+#include <map>
 
 #pragma pack(push)
 #pragma pack(1)
@@ -70,20 +71,24 @@ struct PMSG_ANS_REMOVEERTEL
 
 struct PMSG_REQ_ERTELLIST
 {
-	PBMSG_HEAD h;
-	int aIndex;
-	char szAccount[10];
-	char szName[10];
+        PBMSG_HEAD h;
+        int aIndex;
+        char szAccount[10];
+        char szName[10];
+        DWORD dwSequence;
+        DWORD dwCRC;
 };
 
 struct PMSG_ANS_ERTELLIST
 {
-	PWMSG_HEAD h;
-	int aIndex;
-	char szName[10];
+        PWMSG_HEAD h;
+        int aIndex;
+        char szName[10];
 
-	BYTE ErtelList1[700];
-	BYTE ErtelList2[700];
+        BYTE ErtelList1[700];
+        BYTE ErtelList2[700];
+        DWORD dwSequence;
+        DWORD dwCRC;
 };
 
 struct PMSG_SAVE_ERTELLIST
@@ -304,21 +309,34 @@ public:
 	void ErrtelRankUp(LPOBJ lpObj,BYTE btRank);
 	void PentagramMix(LPOBJ lpObj);
 
-	// DB 
-	void GDReqErtelList(int aIndex);
-	void DGAnsErtelList(PMSG_ANS_ERTELLIST* lpMsg);
-	void GDSaveErtelList(int aIndex);
+        // DB
+        void GDReqErtelList(int aIndex);
+        void DGAnsErtelList(PMSG_ANS_ERTELLIST* lpMsg);
+        void GDSaveErtelList(int aIndex);
+
+        DWORD BuildErtelDataCRC(const BYTE* list1, int list1Size, const BYTE* list2, int list2Size) const;
+        DWORD BuildErtelRequestCRC(const char* account, const char* name) const;
+        DWORD GetPendingErtelSequence(int aIndex) const;
+        void CompleteErtelSequence(int aIndex);
+        bool CanRetryErtelRequest(int aIndex) const;
+        int GetErtelRetryCount(int aIndex) const;
 
 public:
 	ELEMENT_CLASS_INFO m_classinfo[MAX_TYPE_PLAYER];
 	BYTE m_DamageTable[5][5];
 	ERTEL_OPTION m_ErtelOption[MAX_ERTEL_OPTION];
-	PENTAGRAM_OPTION m_PentagramItems[MAX_PENTAGRAM_ITEMS];
-	PENTAGRAM_OPTION_INFO m_PentagramOptionInfo[MAX_PENTAGRAM_OPTIONS];
+        PENTAGRAM_OPTION m_PentagramItems[MAX_PENTAGRAM_ITEMS];
+        PENTAGRAM_OPTION_INFO m_PentagramOptionInfo[MAX_PENTAGRAM_OPTIONS];
 
 
-	TRandomPoolMgr m_OptionRate;
-	TRandomPoolMgr m_SlotCountRate;
+        TRandomPoolMgr m_OptionRate;
+        TRandomPoolMgr m_SlotCountRate;
+
+private:
+        DWORD GetNextErtelSequence();
+        DWORD m_ErtelSequenceCounter;
+        std::map<int, DWORD> m_mapPendingErtelSequences;
+        std::map<int, int> m_mapErtelRetryCount;
 
 	int m_iSpiritMap_DropLevel;
 	int m_iSpiritMap_DropRate;


### PR DESCRIPTION
## Summary
- extend Ertel list request/response structs with sequence and CRC tracking
- generate CRC values when issuing requests and storing sequences for retry handling
- validate incoming packets in DSProtocol and log/resend requests when corruption is detected

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c9bd6a685c83329248bcdd8a697d87